### PR TITLE
Add Proximity Prompt contextual buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Used in my collection of open-source showcases under my group, [The Winner Games
 | **Minimal Mouse Icon** | Changes the default [mouse icon](https://create.roblox.com/docs/reference/engine/classes/UserInputService#MouseIcon) to a more minimal cursor used on console. |
 | **Sprint Script** | Allows users to sprint by holding the left side <kbd>Shift</kbd> key, gamepad X button, or on-screen touch button. |
 | **Premium Chat Tag** | Adds a premium [chat tag](https://create.roblox.com/docs/chat/customizing-in-experience-text-chat#adding-chat-tags) to users with [Premium](https://www.roblox.com/premium/membership). |
+| **Contextual Proximity Prompt** | Creates a [contextual mobile button](https://create.roblox.com/docs/input/mobile#context-dependent-inputs) for triggering proximity prompts. [Example](https://youtu.be/WAwuNaPIkTs) |
+| **Seat Prompt** | Proximity prompts to sit in a seat when a user is near a seat with the [tag](https://create.roblox.com/docs/reference/engine/classes/CollectionService) `Seat`. |
 
 ### Features
 

--- a/src/client/ContextProximityPrompt.client.luau
+++ b/src/client/ContextProximityPrompt.client.luau
@@ -14,11 +14,6 @@ local UserInputService = game:GetService("UserInputService")
 ProximityPromptService.PromptShown:Connect(function(prompt: ProximityPrompt): ()
 	local promptActionName: string = prompt.Name
 
-	-- Don't create a button if the user is not on mobile
-	if UserInputService:GetLastInputType() ~= Enum.UserInputType.Touch then
-		return
-	end
-
 	-- Create the action
 	local function handleAction(actionName: string, inputState: Enum.UserInputState): ()
 		if actionName == promptActionName then

--- a/src/client/ContextProximityPrompt.client.luau
+++ b/src/client/ContextProximityPrompt.client.luau
@@ -1,0 +1,43 @@
+--!strict
+
+--[[
+	Automatically creates a context button for triggering a ProximityPrompt on mobile.
+
+	https://create.roblox.com/docs/input/mobile#context-dependent-inputs
+]]
+
+local ContextActionService = game:GetService("ContextActionService")
+local ProximityPromptService = game:GetService("ProximityPromptService")
+local UserInputService = game:GetService("UserInputService")
+
+-- Create the action when the prompt is shown (mobile button)
+ProximityPromptService.PromptShown:Connect(function(prompt: ProximityPrompt): ()
+	local promptActionName: string = prompt.Name
+
+	-- Don't create a button if the user is not on mobile
+	if UserInputService:GetLastInputType() ~= Enum.UserInputType.Touch then
+		return
+	end
+
+	-- Create the action
+	local function handleAction(actionName: string, inputState: Enum.UserInputState): ()
+		if actionName == promptActionName then
+			if inputState == Enum.UserInputState.Begin then
+				prompt:InputHoldBegin()
+			else
+				prompt:InputHoldEnd()
+			end
+		end
+	end
+
+	-- Bind the action
+	ContextActionService:BindAction(promptActionName, handleAction, true)
+	ContextActionService:SetPosition(promptActionName, UDim2.new(1, -70, 0, 10))
+	ContextActionService:SetImage(promptActionName, "rbxasset://textures/ui/Controls/TouchTapIcon.png")
+end)
+
+-- Remove the action when the prompt is hidden
+ProximityPromptService.PromptHidden:Connect(function(prompt: ProximityPrompt): ()
+	local promptActionName: string = prompt.Name
+	ContextActionService:UnbindAction(promptActionName)
+end)

--- a/src/client/ContextProximityPrompt.client.luau
+++ b/src/client/ContextProximityPrompt.client.luau
@@ -32,7 +32,7 @@ ProximityPromptService.PromptShown:Connect(function(prompt: ProximityPrompt): ()
 
 	-- Bind the action
 	ContextActionService:BindAction(promptActionName, handleAction, true)
-	ContextActionService:SetPosition(promptActionName, UDim2.new(1, -70, 0, 10))
+	ContextActionService:SetPosition(promptActionName, UDim2.new(1, -140, 0, 10))
 	ContextActionService:SetImage(promptActionName, "rbxasset://textures/ui/Controls/TouchTapIcon.png")
 end)
 

--- a/src/client/ContextProximityPrompt.client.luau
+++ b/src/client/ContextProximityPrompt.client.luau
@@ -8,11 +8,11 @@
 
 local ContextActionService = game:GetService("ContextActionService")
 local ProximityPromptService = game:GetService("ProximityPromptService")
-local UserInputService = game:GetService("UserInputService")
 
 -- Create the action when the prompt is shown (mobile button)
 ProximityPromptService.PromptShown:Connect(function(prompt: ProximityPrompt): ()
 	local promptActionName: string = prompt.Name
+	local promptActionTitle: string = prompt.ActionText
 
 	-- Create the action
 	local function handleAction(actionName: string, inputState: Enum.UserInputState): ()
@@ -28,7 +28,7 @@ ProximityPromptService.PromptShown:Connect(function(prompt: ProximityPrompt): ()
 	-- Bind the action
 	ContextActionService:BindAction(promptActionName, handleAction, true)
 	ContextActionService:SetPosition(promptActionName, UDim2.new(1, -140, 0, 10))
-	ContextActionService:SetImage(promptActionName, "rbxasset://textures/ui/Controls/TouchTapIcon.png")
+	ContextActionService:SetTitle(promptActionName, promptActionTitle)
 end)
 
 -- Remove the action when the prompt is hidden

--- a/src/client/Sprint.client.luau
+++ b/src/client/Sprint.client.luau
@@ -63,12 +63,3 @@ ContextActionService:SetPosition(SPRINT_ACTION, UDim2.new(1, -70, 0, 10))
 ContextActionService:SetTitle(SPRINT_ACTION, TranslationHelper.translate(SPRINT_ACTION_TITLE, script))
 -- Set the description of the mobile button
 ContextActionService:SetDescription(SPRINT_ACTION, SPRINT_ACTION_DESCRIPTION)
-
--- If the player changes their locale, update the mobile button's title
-local onLocaleIdChangedSignal: RBXScriptSignal | false = TranslationHelper.onLocaleIdChanged()
-
-if onLocaleIdChangedSignal ~= false then
-	onLocaleIdChangedSignal:Connect(function(): ()
-		ContextActionService:SetTitle(SPRINT_ACTION, TranslationHelper.translate(SPRINT_ACTION_TITLE, script))
-	end)
-end

--- a/src/server/SeatPrompt.server.luau
+++ b/src/server/SeatPrompt.server.luau
@@ -1,0 +1,70 @@
+--!strict
+
+--[[
+	Automatically creates a ProximityPrompt for each Seat in the workspace.
+	When the prompt is triggered, the player will sit in the seat.
+
+	https://create.roblox.com/docs/reference/engine/classes/ProximityPrompt
+]]
+
+local CollectionService = game:GetService("CollectionService")
+
+local tag: string = script:GetAttribute("SeatTagName") :: string or "Seat"
+local objectText: string = script:GetAttribute("ObjectText") :: string or "Seat"
+local actionText: string = script:GetAttribute("ActionText") :: string or "Sit"
+local holdDuration: number = script:GetAttribute("HoldDuration") :: number or 0.25
+local requiresLineOfSight: boolean = script:GetAttribute("RequiresLineOfSight") :: boolean or false
+local disableSeatTouch: boolean = script:GetAttribute("DisableSeatTouch") :: boolean or true
+
+local function onInstanceAdded(object: Instance): ()
+	-- Remember that any tag can be applied to any object, so there's no
+	-- guarantee that the object with this tag is a BasePart.
+	if object:IsA("Seat") and not object.Disabled then
+		-- Disable the seat's touch event if specified
+		if disableSeatTouch then
+			object.CanTouch = false
+		end
+
+		-- Create a proximity prompt for the seat
+		local seatPrompt: ProximityPrompt = Instance.new("ProximityPrompt")
+		seatPrompt.Name = "SeatProximityPrompt"
+		seatPrompt.ObjectText = objectText
+		seatPrompt.ActionText = actionText
+		seatPrompt.HoldDuration = holdDuration
+		seatPrompt.RequiresLineOfSight = requiresLineOfSight
+		seatPrompt.Parent = object
+
+		-- Hide the prompt when the seat is occupied
+		object:GetPropertyChangedSignal("Occupant"):Connect(function(): ()
+			if object.Occupant then
+				seatPrompt.Enabled = false
+			else
+				seatPrompt.Enabled = true
+			end
+		end)
+
+		-- Sit the player when the prompt is triggered
+		seatPrompt.Triggered:Connect(function(player: Player): ()
+			local character: Model = player.Character :: Model
+			local humanoid: Humanoid = character:WaitForChild("Humanoid") :: Humanoid
+			object:Sit(humanoid)
+		end)
+	end
+end
+
+local function onInstanceRemoved(object: Instance): ()
+	-- If we made a connection on this object, disconnect it (prevent memory leaks)
+	local seatPrompt: ProximityPrompt = object:FindFirstChild("SeatProximityPrompt") :: ProximityPrompt
+	if seatPrompt then
+		seatPrompt:Destroy()
+	end
+end
+
+-- Listen for this tag being applied to objects
+CollectionService:GetInstanceAddedSignal(tag):Connect(onInstanceAdded)
+CollectionService:GetInstanceRemovedSignal(tag):Connect(onInstanceRemoved)
+
+-- Also detect any objects that already have the tag
+for _, object: Instance in pairs(CollectionService:GetTagged(tag)) do
+	onInstanceAdded(object)
+end

--- a/src/server/SeatPrompt.server.luau
+++ b/src/server/SeatPrompt.server.luau
@@ -12,7 +12,7 @@ local CollectionService = game:GetService("CollectionService")
 local tag: string = script:GetAttribute("SeatTagName") :: string or "Seat"
 local objectText: string = script:GetAttribute("ObjectText") :: string or "Seat"
 local actionText: string = script:GetAttribute("ActionText") :: string or "Sit"
-local holdDuration: number = script:GetAttribute("HoldDuration") :: number or 0.25
+local holdDuration: number = script:GetAttribute("HoldDuration") :: number or 0
 local requiresLineOfSight: boolean = script:GetAttribute("RequiresLineOfSight") :: boolean or false
 local disableSeatTouch: boolean = script:GetAttribute("DisableSeatTouch") :: boolean or true
 


### PR DESCRIPTION
## Description

Adds contextual buttons for proximity prompts and adds proximity prompts to all seats with the `Seat` tag.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* Add script to for contextual buttons for proximity prompts
* Add script to add proximity prompts to scripts
* Fix translations for sprint

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->

## Code of Conduct

By submitting this issue, I agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
